### PR TITLE
Fix: Prevent collapsing code blocks from hiding content between blocks

### DIFF
--- a/src/readView.ts
+++ b/src/readView.ts
@@ -54,28 +54,10 @@ export function setupReadView(app: ExtendedApp, settings: CollapsibleCodeBlockSe
     }
 
     function updateCodeBlockVisibility(pre: HTMLElement, forceRefresh: boolean = false) {
-        const isCollapsed = pre.classList.contains('collapsed');
         const markdownView = app.workspace.getActiveViewOfType(MarkdownView);
         if (!markdownView?.previewMode?.containerEl) return;
 
         const previewElement = markdownView.previewMode.containerEl;
-        const rect = pre.getBoundingClientRect();
-        const scrollTop = previewElement.scrollTop;
-        const elementTop = rect.top + scrollTop;
-
-        let curr = pre.nextElementSibling;
-        while (curr && !(curr instanceof HTMLPreElement)) {
-            if (curr instanceof HTMLElement) {
-                if (isCollapsed) {
-                    curr.classList.add('element-hidden');
-                    curr.classList.remove('element-visible', 'element-spacing');
-                } else {
-                    curr.classList.remove('element-hidden');
-                    curr.classList.add('element-visible');
-                }
-            }
-            curr = curr.nextElementSibling;
-        }
 
         void pre.offsetHeight;
 

--- a/styles.css
+++ b/styles.css
@@ -81,23 +81,6 @@ body[data-ccb-horizontal-scroll="true"] .markdown-preview-view pre.ccb-code-bloc
     width: 0;
 }
 
-/* New styles for dynamic states */
-.hidden {
-    display: none !important;
-}
-
-.element-hidden {
-    display: none !important;
-}
-
-.element-visible {
-    display: block;
-}
-
-.element-spacing {
-    margin-top: var(--element-spacing);
-}
-
 /* Custom properties for dynamic values */
 :root {
     --element-spacing: 0px;


### PR DESCRIPTION
**Issue:**
When a code block was collapsed, the `updateCodeBlockVisibility` function 
incorrectly hid all sibling HTML elements between the collapsed block and 
the next code block. This caused content like notes, paragraphs, or headings 
positioned between code blocks to disappear from view.

**Root Cause:**
The function used a while loop to iterate through `nextElementSibling` nodes
and applied the `element-hidden` class to hide them, treating inter-block 
content as part of the collapsed code block.

**Solution:**
- Removed the logic that hides sibling elements in `updateCodeBlockVisibility()`
- Kept only the reflow trigger to ensure proper scroll/layout behavior
- Cleaned up unused CSS classes: `.hidden`, `.element-hidden`, 
  `.element-visible`, `.element-spacing`

**Result:**
Code blocks now collapse independently without affecting surrounding content.
Inter-block elements (notes, text, headings) remain visible as expected.